### PR TITLE
Fix typo for getLoginURL()

### DIFF
--- a/components/Simplesamlphp.php
+++ b/components/Simplesamlphp.php
@@ -87,7 +87,7 @@ class Simplesamlphp extends CApplicationComponent {
      * @see https://simplesamlphp.org/docs/stable/simplesamlphp-sp-api#section_8
      */
     public function getLoginURL($returnTo = null) {
-        $this->authSimple->getLogoutUrl($returnTo);
+        $this->authSimple->getLoginURL($returnTo);
     }
 
     /**


### PR DESCRIPTION
changed getLogoutUrl to getLoginURL as per https://simplesamlphp.org/docs/stable/simplesamlphp-sp-api#section_8